### PR TITLE
Check length of post-split slice, not of original string

### DIFF
--- a/nomad.go
+++ b/nomad.go
@@ -77,7 +77,7 @@ func processQName(qname string) (string, string) {
 
 func extractNamespaceAndService(qname string) (string, string, error) {
 	qnameSplit := dns.SplitDomainName(qname)
-	if len(qname) < 2 {
+	if len(qnameSplit) < 2 {
 		return "", "", fmt.Errorf("invalid query name")
 	}
 	return qnameSplit[1], qnameSplit[0], nil


### PR DESCRIPTION
Avoids panic'ing coredns for improper-length queries:

```
λ dig +short @node1.nomad.test traefik.service.nomad
...timeout...

Meanwhile the nomad task:

goroutine 437 [running]:
github.com/ituoga/coredns-nomad.extractNamespaceAndService({0xc00080a5d0?, 0x7})
	/go/pkg/mod/github.com/ituoga/coredns-nomad@v0.0.6/nomad.go:85 +0x8e
github.com/ituoga/coredns-nomad.Nomad.ServeDNS({{0x0, 0x0}, 0x1e, {0xc000117ee8, 0x1, 0x1}, 0x0}, {0x28fbd98, 0xc0006ffa40}, {0x2903838, ...}, ...)
	/go/pkg/mod/github.com/ituoga/coredns-nomad@v0.0.6/nomad.go:48 +0xda
...
panic: runtime error: index out of range [1] with length 1